### PR TITLE
#36 fix bug. plt.close()

### DIFF
--- a/GolfMEMD/plot.py
+++ b/GolfMEMD/plot.py
@@ -33,3 +33,4 @@ def plot(
     file_name = '_'.join(imf_name[start:end])
     # print('save figure', os.path.join(save_path, file_name) )
     plt.savefig(os.path.join(save_path, file_name))
+    plt.close()


### PR DESCRIPTION
`plt.savefig`を行った際に，メモリ上にはまだデータが残っているためwarningが出力されていた．
`plt.close`を実行することで，savefigしたデータをメモリから削除することで解決した．